### PR TITLE
add support for nested virtualization

### DIFF
--- a/osversion.go
+++ b/osversion.go
@@ -105,6 +105,8 @@ func macOSBuildTargetAvailable(version float64) error {
 		target = 130000 // __MAC_13_0
 	case 14:
 		target = 140000 // __MAC_14_0
+	case 15:
+		target = 150000 // __MAC_15_0
 	}
 	if allowedVersion < target {
 		return fmt.Errorf("%w for %.1f (the binary was built with __MAC_OS_X_VERSION_MAX_ALLOWED=%d; needs recompilation)",

--- a/platform.go
+++ b/platform.go
@@ -6,6 +6,7 @@ package vz
 # include "virtualization_11.h"
 # include "virtualization_12.h"
 # include "virtualization_13.h"
+# include "virtualization_15.h"
 */
 import "C"
 import (
@@ -38,6 +39,28 @@ type GenericPlatformConfiguration struct {
 // MachineIdentifier returns the machine identifier.
 func (m *GenericPlatformConfiguration) MachineIdentifier() *GenericMachineIdentifier {
 	return m.machineIdentifier
+}
+
+// IsNestedVirtualizationSupported reports if nested virtualization is supported.
+func IsNestedVirtualizationSupported() bool {
+	if err := macOSAvailable(15); err != nil {
+		return false
+	}
+
+	return (bool)(C.isNestedVirtualizationSupported())
+}
+
+// SetNestedVirtualizationEnabled toggles nested virtualization.
+func (m *GenericPlatformConfiguration) SetNestedVirtualizationEnabled(enable bool) error {
+	if err := macOSAvailable(15); err != nil {
+		return err
+	}
+
+	C.setNestedVirtualizationEnabled(
+		objc.Ptr(m),
+		C.bool(enable),
+	)
+	return nil
 }
 
 var _ PlatformConfiguration = (*GenericPlatformConfiguration)(nil)

--- a/virtualization_15.h
+++ b/virtualization_15.h
@@ -1,0 +1,15 @@
+//
+//  virtualization_15.h
+
+#pragma once
+
+// FIXME(codehex): this is dirty hack to avoid clang-format error like below
+// "Configuration file(s) do(es) not support C++: /github.com/Code-Hex/vz/.clang-format"
+#define NSURLComponents NSURLComponents
+
+#import "virtualization_helper.h"
+#import <Virtualization/Virtualization.h>
+
+/* macOS 15 API */
+bool isNestedVirtualizationSupported();
+void setNestedVirtualizationEnabled(void *config, bool nestedVirtualizationEnabled);

--- a/virtualization_15.m
+++ b/virtualization_15.m
@@ -1,0 +1,33 @@
+//
+//  virtualization_15.m
+//
+#import "virtualization_15.h"
+
+/*!
+ @abstract Check if nested virtualization is supported.
+ @return true if supported.
+ */
+bool isNestedVirtualizationSupported()
+{
+#ifdef INCLUDE_TARGET_OSX_15
+    if (@available(macOS 15, *)) {
+        return (bool) VZGenericPlatformConfiguration.isNestedVirtualizationSupported;
+    }
+#endif
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
+}
+
+/*!
+ @abstract Set nestedVirtualizationEnabled. The default is false.
+ */
+void setNestedVirtualizationEnabled(void *config, bool nestedVirtualizationEnabled)
+{
+#ifdef INCLUDE_TARGET_OSX_15
+    if (@available(macOS 15, *)) {
+        VZGenericPlatformConfiguration *platformConfig = (VZGenericPlatformConfiguration *)config;
+        platformConfig.nestedVirtualizationEnabled = (BOOL) nestedVirtualizationEnabled;
+        return;
+    }
+#endif
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
+}

--- a/virtualization_helper.h
+++ b/virtualization_helper.h
@@ -39,6 +39,13 @@ NSDictionary *dumpProcessinfo();
 #pragma message("macOS 14 API has been disabled")
 #endif
 
+// for macOS 15 API
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 150000
+#define INCLUDE_TARGET_OSX_15 1
+#else
+#pragma message("macOS 15 API has been disabled")
+#endif
+
 static inline int mac_os_x_version_max_allowed()
 {
 #ifdef __MAC_OS_X_VERSION_MAX_ALLOWED


### PR DESCRIPTION
## Which issue(s) this PR fixes:

This PR adds support for nested virtualization, [added in macOS 15 for m3 devices](https://developer.apple.com/documentation/virtualization/vzgenericplatformconfiguration/4360553-nestedvirtualizationsupported?language=objc).

## Additional documentation

Sample usage
```go
platformConfig, err := vz.NewGenericPlatformConfiguration(vz.WithGenericMachineIdentifier(machineIdentifier))
if err != nil {
	return err
}

// nested virt
platformConfig.SetNestedVirtualizationEnabled(true)
```

<!--
This section can be blank.
-->
