### PR TITLE
added VZNetworkBlockDeviceStorageDeviceAttachment

### DIFF
--- a/osversion_test.go
+++ b/osversion_test.go
@@ -319,6 +319,10 @@ func TestAvailableVersion(t *testing.T) {
 				_, err := NewDiskBlockDeviceStorageDeviceAttachment(nil, false, DiskSynchronizationModeFull)
 				return err
 			},
+			"NewNetworkBlockDeviceStorageDeviceAttachment": func() error {
+				_, err := NewNetworkBlockDeviceStorageDeviceAttachment("", 0, false, DiskSynchronizationModeFull)
+				return err
+			},
 		}
 		for name, fn := range cases {
 			t.Run(name, func(t *testing.T) {

--- a/virtualization_14.h
+++ b/virtualization_14.h
@@ -16,3 +16,4 @@
 /* macOS 14 API */
 void *newVZNVMExpressControllerDeviceConfiguration(void *attachment);
 void *newVZDiskBlockDeviceStorageDeviceAttachment(int fileDescriptor, bool readOnly, int syncMode, void **error);
+void *newVZNetworkBlockDeviceStorageDeviceAttachment(const char *url, double timeout, bool forcedReadOnly, int syncMode, void **error);

--- a/virtualization_14.m
+++ b/virtualization_14.m
@@ -51,3 +51,36 @@ void *newVZDiskBlockDeviceStorageDeviceAttachment(int fileDescriptor, bool readO
 #endif
     RAISE_UNSUPPORTED_MACOS_EXCEPTION();
 }
+
+/*!
+ @abstract Initialize a network block device storage attachment from an NBD URI.
+ @param uri The NBD’s URI represented as a URL.
+ @param timeout The timeout value in seconds for the connection between the client and server. When the timeout expires, an attempt to reconnect with the server takes place.
+ @param forcedReadOnly If YES, the framework forces the disk attachment to be read-only, regardless of whether or not the NBD server supports write requests.
+ @param synchronizationMode Defines how the disk synchronizes with the underlying storage when the guest operating system flushes data.
+ @param error If not nil, assigned with the error if the initialization failed.
+ @return An initialized `VZDiskBlockDeviceStorageDeviceAttachment` or nil if there was an error.
+ @discussion
+    The forcedReadOnly parameter affects how framework exposes the NBD client to the guest operating
+    system by the storage controller. As part of the NBD protocol, the NBD server advertises whether
+    or not the disk exposed by the NBD client is read-only during the handshake phase of the protocol.
+
+    Setting forcedReadOnly to YES forces the NBD client to show up as read-only to the guest
+    regardless of whether or not the NBD server advertises itself as read-only.
+ */
+void *newVZNetworkBlockDeviceStorageDeviceAttachment(const char *uri, double timeout, bool forcedReadOnly, int syncMode, void **error)
+{
+#ifdef INCLUDE_TARGET_OSX_14
+    if (@available(macOS 14, *)) {
+        NSURL *url = [NSURL URLWithString:[NSString stringWithUTF8String:uri]];
+
+        return [[VZNetworkBlockDeviceStorageDeviceAttachment alloc]
+                    initWithURL:url
+                        timeout:(NSTimeInterval)timeout
+                 forcedReadOnly:(BOOL)forcedReadOnly
+            synchronizationMode:(VZDiskSynchronizationMode)syncMode
+                          error:(NSError *_Nullable *_Nullable)error];
+    }
+#endif
+    RAISE_UNSUPPORTED_MACOS_EXCEPTION();
+}


### PR DESCRIPTION
Further to https://github.com/Code-Hex/vz/pull/142, this adds [VZNetworkBlockDeviceStorageDeviceAttachment](https://developer.apple.com/documentation/virtualization/vznetworkblockdevicestoragedeviceattachment?language=objc) support.

This PR lacks setting a [delegate](https://developer.apple.com/documentation/virtualization/vznetworkblockdevicestoragedeviceattachment/4168502-delegate?language=objc) to monitor state changes to the attachment, mostly because I couldn't figure out the best way to integrate this and it would probably lead to a much larger PR. Hopefully that can be done in a follow-up.

I've updated the MacOS application to ease testing. You can serve an existing raw disk within the bundle directory with `qemu-nbd`:

```shell
qemu-nbd -k $(pwd)/source.sock -f raw -x export --cache=none disk.img
```

And then run:

```
./macOS -nbd-url "nbd+unix:///export?socket=source.sock"
```

The `-install` option also works well with this argument if you serve a disk created with `qemu-img`.

This is great news as it gives access to `qemu`'s `qcow2` format and linked disks functionality.

Relates to https://github.com/Code-Hex/vz/issues/143